### PR TITLE
fix(bash): missing 'set e'

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,46 +1,49 @@
 #!/bin/bash
+set -e
 
 # Set path
-echo '::group::Copying file from $WORKPATH to /tmp/gh-action'
+echo "::group::Copying file from $WORKPATH to /tmp/gh-action"
 WORKPATH=$GITHUB_WORKSPACE/$INPUT_PATH
 # Set path permision
 sudo -u builder mkdir /tmp/gh-action
-sudo -u builder cp -rfv $WORKPATH/.git /tmp/gh-action/.git
-sudo -u builder cp -fv $WORKPATH/PKGBUILD /tmp/gh-action/PKGBUILD
+sudo -u builder cp -rfv "$WORKPATH"/.git /tmp/gh-action/.git
+sudo -u builder cp -fv "$WORKPATH"/PKGBUILD /tmp/gh-action/PKGBUILD
 cd /tmp/gh-action
-echo '::endgroup::'
+echo "::endgroup::"
 
 # Update checksums
-echo '::group::Updating checksums on PKGBUILD'
 if [[ $INPUT_UPDPKGSUMS == true ]]; then
+    echo "::group::Updating checksums on PKGBUILD"
     sudo -u builder updpkgsums
     git diff PKGBUILD
+    echo "::endgroup::"
 fi
-echo '::endgroup::'
 
 # Generate .SRCINFO
-echo '::group::Generating new .SRCINFO based on PKGBUILD'
 if [[ $INPUT_SRCINFO == true ]]; then
+    echo "::group::Generating new .SRCINFO based on PKGBUILD"
     sudo -u builder makepkg --printsrcinfo > .SRCINFO
     git diff .SRCINFO
+    echo "::endgroup::"
 fi
-echo '::endgroup::'
 
 # Validate with namcap
-echo '::group::Validating PKGBUILD with namcap'
 if [[ $INPUT_NAMCAP == true ]]; then
+    echo "::group::Validating PKGBUILD with namcap"
     namcap -i PKGBUILD
+    echo "::endgroup::"
 fi
-echo '::endgroup::'
 
 # Run makepkg
-echo '::group::Running makepkg with flags'
-if [[ -n "$INPUT_FLAGS" ]]; then
+if [[ -n $INPUT_FLAGS ]]; then
+    echo "::group::Running makepkg with flags"
     sudo -u builder makepkg $INPUT_FLAGS
+    echo "::endgroup::"
 fi
-echo '::endgroup::'
 
-echo '::group::Copying files from /tmp/gh-action to $WORKPATH'
-cp -fv /tmp/gh-action/PKGBUILD $WORKPATH/PKGBUILD
-cp -fv /tmp/gh-action/.SRCINFO $WORKPATH/.SRCINFO
-echo '::endgroup::'
+echo "::group::Copying files from /tmp/gh-action to $WORKPATH"
+cp -fv /tmp/gh-action/PKGBUILD "$WORKPATH"/PKGBUILD
+if [[ -e /tmp/gh-action/.SRCINFO ]]; then
+    cp -fv /tmp/gh-action/.SRCINFO "$WORKPATH"/.SRCINFO
+fi
+echo "::endgroup::"


### PR DESCRIPTION
 This PR will add missing `set -e` on `entrypoint.sh`, as described in the #1 issue.